### PR TITLE
feat(playwright): support configuring depth for scraping

### DIFF
--- a/playwright/src/rustic_ai/playwright/agent.py
+++ b/playwright/src/rustic_ai/playwright/agent.py
@@ -1,4 +1,3 @@
-import asyncio
 from enum import StrEnum
 import hashlib
 import logging
@@ -208,7 +207,6 @@ class PlaywrightScraperAgent(Agent):
                     )
 
             await browser.close()
-            await asyncio.sleep(0.1)
 
             unique_scraped_docs = list({doc.name: doc for doc in scraped_docs}.values())
 

--- a/playwright/src/rustic_ai/playwright/agent.py
+++ b/playwright/src/rustic_ai/playwright/agent.py
@@ -3,8 +3,8 @@ import hashlib
 import logging
 import mimetypes
 import os
-from typing import List
-from urllib.parse import urlsplit
+from typing import List, Set
+from urllib.parse import urljoin, urlsplit
 
 from install_playwright import install
 from markdownify import markdownify as md
@@ -39,6 +39,17 @@ class WebScrapingRequest(BaseModel):
         description="Options for the transformer to be applied to the scraped content. Default is an empty dictionary.",
     )
 
+    scrape_nav_links: int = Field(
+        default=0,
+        title="Number of links to scrape from nav bar",
+        description="The number of links to scrape from navigation bar of website, -1 to scrape all",
+    )
+    force: bool = Field(
+        default=False,
+        title="Force scrape the url",
+        description="Even if the url was scraped earlier will scrape it if force is set to true. This is used to avoid same url to be scrapped multiple times",
+    )
+
 
 class WebScrapingCompleted(BaseModel):
     id: str = Field(..., title="ID of the request")
@@ -48,6 +59,7 @@ class WebScrapingCompleted(BaseModel):
 class PlaywrightScraperAgent(Agent):
     def __init__(self, agent_spec: AgentSpec):
         super().__init__(agent_spec=agent_spec)
+        self.scraped_urls: Set[str] = set()
 
     @agent.processor(
         WebScrapingRequest, depends_on=[agent.AgentDependency(dependency_key="filesystem", guild_level=True)]
@@ -63,70 +75,105 @@ class PlaywrightScraperAgent(Agent):
             scraped_docs: List[MediaLink] = []
 
             for link in scraping_request.links:
-                url = link.url
 
-                response = await page.goto(url)
+                async def scrape_and_store(current_url: str):
+                    response = await page.goto(current_url)
 
-                if response and response.status != 200:
-                    ctx.send_error(
-                        ErrorMessage(
-                            agent_type=self.get_qualified_class_name(),
-                            error_type="HTTP_ERROR_{response.status}",
-                            error_message=f"HTTP error: {response.status} for URL: {url}. Error message: {response.status_text}",
+                    if response and response.status != 200:
+                        ctx.send_error(
+                            ErrorMessage(
+                                agent_type=self.get_qualified_class_name(),
+                                error_type="HTTP_ERROR_{response.status}",
+                                error_message=f"HTTP error: {response.status} for URL: {current_url}. Error message: {response.status_text}",
+                            )
                         )
+                        return
+
+                    title = await page.title()
+                    content = await page.content()
+                    urls = urlsplit(current_url)
+                    upath = urls.path
+                    basename = os.path.basename(upath)
+                    _, filetype = os.path.splitext(basename)
+
+                    if not filetype and scraping_request.output_format == ScrapingOutputFormat.TEXT_HTML:
+                        filetype = ".html"
+                    elif scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
+                        filetype = ".md"
+                    elif not filetype:
+                        filetype = ".txt"
+
+                    filename = hashlib.md5(content.encode("utf-8")).hexdigest() + filetype
+
+                    mimetype = mimetypes.guess_type(filename)[0]
+
+                    try:
+                        if scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
+                            content = md(
+                                content,
+                                **scraping_request.transformer_options,
+                            )
+                        with filesystem.open(f"scraped_data/{filename}", "w") as f:
+                            f.write(content)
+                    except Exception as e:
+                        logging.error(f"Error writing file: {e}")
+                        ctx.send_error(
+                            ErrorMessage(
+                                agent_type=self.get_qualified_class_name(),
+                                error_type="FileWriteError",
+                                error_message=str(e),
+                            )
+                        )
+
+                    meta = link.metadata or {}
+                    metadata = meta | {"scraped_url": current_url, "title": title, "request_id": scraping_request.id}
+
+                    output = MediaLink(
+                        url=f"scraped_data/{filename}",
+                        name=filename,
+                        metadata=metadata,
+                        on_filesystem=True,
+                        mimetype=mimetype,
+                        encoding="utf-8",
                     )
-                    continue
 
-                title = await page.title()
-                content = await page.content()
-                urls = urlsplit(url)
-                upath = urls.path
-                basename = os.path.basename(upath)
-                _, filetype = os.path.splitext(basename)
+                    scraped_docs.append(output)
+                    self.scraped_urls.add(current_url)
+                    ctx.send(output)
 
-                if not filetype and scraping_request.output_format == ScrapingOutputFormat.TEXT_HTML:
-                    filetype = ".html"
-                elif scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
-                    filetype = ".md"
-                elif not filetype:
-                    filetype = ".txt"
+                if link.url not in self.scraped_urls or scraping_request.force:
+                    await scrape_and_store(link.url)
 
-                filename = hashlib.md5(content.encode("utf-8")).hexdigest() + filetype
+                if scraping_request.scrape_nav_links != 0:
 
-                mimetype = mimetypes.guess_type(filename)[0]
-
-                try:
-                    if scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
-                        content = md(
-                            content,
-                            **scraping_request.transformer_options,
-                        )
-                    with filesystem.open(f"scraped_data/{filename}", "w") as f:
-                        f.write(content)
-                except Exception as e:
-                    logging.error(f"Error writing file: {e}")
-                    ctx.send_error(
-                        ErrorMessage(
-                            agent_type=self.get_qualified_class_name(),
-                            error_type="FileWriteError",
-                            error_message=str(e),
-                        )
+                    # Scrape from navigation bar links
+                    nav_links = await page.eval_on_selector_all(
+                        "nav a[href], header a[href]",  # This targets common nav structures
+                        "elements => elements.map(el => el.href)",
                     )
 
-                meta = link.metadata or {}
-                metadata = meta | {"scraped_url": url, "title": title, "request_id": scraping_request.id}
+                    unique_links = set()
+                    for nav_link in nav_links:
+                        full_url = urljoin(link.url, nav_link)
+                        if (full_url not in unique_links) and (full_url not in self.scraped_urls):
+                            unique_links.add(full_url)
 
-                output = MediaLink(
-                    url=f"scraped_data/{filename}",
-                    name=filename,
-                    metadata=metadata,
-                    on_filesystem=True,
-                    mimetype=mimetype,
-                    encoding="utf-8",
-                )
-
-                scraped_docs.append(output)
-                ctx.send(output)
+                    count_links = (
+                        len(unique_links)
+                        if scraping_request.scrape_nav_links == -1
+                        else scraping_request.scrape_nav_links
+                    )
+                    for nav_url in list(unique_links)[:count_links]:
+                        try:
+                            await scrape_and_store(nav_url)
+                        except Exception as e:
+                            ctx.send_error(
+                                ErrorMessage(
+                                    agent_type=self.get_qualified_class_name(),
+                                    error_type="SCRAPE_NAV_ERROR",
+                                    error_message=f"Error scraping nav URL {nav_url}: {str(e)}",
+                                )
+                            )
 
             await browser.close()
 

--- a/playwright/src/rustic_ai/playwright/agent.py
+++ b/playwright/src/rustic_ai/playwright/agent.py
@@ -1,3 +1,4 @@
+import asyncio
 from enum import StrEnum
 import hashlib
 import logging
@@ -41,14 +42,14 @@ class WebScrapingRequest(BaseModel):
 
     depth: int = Field(
         default=0,
-        title="Number of links to scrape",
-        description="The number of links to scrape from within the page, -1 to scrape all",
+        title="Depth of recursive link scraping",
+        description="If 0, only scrape the input page. If 1, also scrape all links on the page. If 2, recurse into those links, and so on.",
     )
 
     scrape_external_links: bool = Field(
         default=False,
         title="Scrape external links",
-        description="If depth is greather than 0, and we are scrapping further down the link in the page should links going outside the page be scraped or not",
+        description="If True, allows scraping of links pointing to domains outside the initial one.",
     )
 
     force: bool = Field(
@@ -84,6 +85,104 @@ class PlaywrightScraperAgent(Agent):
                 valid_links.append(full_url)
         return valid_links
 
+    async def scrape_and_store(self, current_link, browser, scraping_request, ctx, scraped_docs, filesystem):
+        if current_link.url in self.scraped_urls and not scraping_request.force:
+            return
+
+        page = await browser.new_page()
+        response = await page.goto(current_link.url)
+
+        if response and response.status != 200:
+            ctx.send_error(
+                ErrorMessage(
+                    agent_type=self.get_qualified_class_name(),
+                    error_type=f"HTTP_ERROR_{response.status}",
+                    error_message=f"HTTP error: {response.status} for URL: {current_link.url}. Error message: {response.status_text}",
+                )
+            )
+            return
+
+        try:
+            title = await page.title()
+            content = await page.content()
+            urls = urlsplit(current_link.url)
+            upath = urls.path
+            basename = os.path.basename(upath)
+            _, filetype = os.path.splitext(basename)
+
+            if not filetype and scraping_request.output_format == ScrapingOutputFormat.TEXT_HTML:
+                filetype = ".html"
+            elif scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
+                filetype = ".md"
+            elif not filetype:
+                filetype = ".txt"
+
+            filename = hashlib.md5(content.encode("utf-8")).hexdigest() + filetype
+
+            mimetype = mimetypes.guess_type(filename)[0]
+
+            if scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
+                content = md(
+                    content,
+                    **scraping_request.transformer_options,
+                )
+            with filesystem.open(f"scraped_data/{filename}", "w") as f:
+                f.write(content)
+
+            meta = current_link.metadata or {}
+            metadata = meta | {"scraped_url": current_link.url, "title": title, "request_id": scraping_request.id}
+
+            output = MediaLink(
+                url=f"scraped_data/{filename}",
+                name=filename,
+                metadata=metadata,
+                on_filesystem=True,
+                mimetype=mimetype,
+                encoding="utf-8",
+            )
+
+            scraped_docs.append(output)
+            self.scraped_urls.add(current_link.url)
+            ctx.send(output)
+
+        except Exception as e:
+            logging.error(f"Error writing file: {e}")
+            ctx.send_error(
+                ErrorMessage(
+                    agent_type=self.get_qualified_class_name(),
+                    error_type="FileWriteError",
+                    error_message=str(e),
+                )
+            )
+
+        return page
+
+    async def _scrape_recursive(self, url: str, depth: int, browser, request, ctx, scraped_docs, filesystem):
+        if url in self.scraped_urls and not request.force:
+            return
+
+        if url.endswith(".zip"):
+            return
+
+        page = await self.scrape_and_store(MediaLink(url=url), browser, request, ctx, scraped_docs, filesystem)
+        if not page or depth == 0:
+            return
+
+        try:
+            links = await self._extract_links(page, url, request)
+            for link in links:
+                await self._scrape_recursive(link, depth - 1, browser, request, ctx, scraped_docs, filesystem)
+        except Exception as e:
+            ctx.send_error(
+                ErrorMessage(
+                    agent_type=self.get_qualified_class_name(),
+                    error_type="SCRAPE_RECURSION_ERROR",
+                    error_message=f"Failed to recurse into links on {url}: {str(e)}",
+                )
+            )
+        finally:
+            await page.close()
+
     @agent.processor(
         WebScrapingRequest, depends_on=[agent.AgentDependency(dependency_key="filesystem", guild_level=True)]
     )
@@ -91,95 +190,25 @@ class PlaywrightScraperAgent(Agent):
         async with async_playwright() as p:
             install(p.chromium)
             browser = await p.chromium.launch()
-            page = await browser.new_page()
             scraping_request = ctx.payload
             scraped_docs: List[MediaLink] = []
 
             for link in scraping_request.links:
-
-                async def scrape_and_store(current_url: str):
-                    response = await page.goto(current_url)
-
-                    if response and response.status != 200:
-                        ctx.send_error(
-                            ErrorMessage(
-                                agent_type=self.get_qualified_class_name(),
-                                error_type=f"HTTP_ERROR_{response.status}",
-                                error_message=f"HTTP error: {response.status} for URL: {current_url}. Error message: {response.status_text}",
-                            )
+                try:
+                    await self._scrape_recursive(
+                        link.url, scraping_request.depth, browser, scraping_request, ctx, scraped_docs, filesystem
+                    )
+                except Exception as e:
+                    ctx.send_error(
+                        ErrorMessage(
+                            agent_type=self.get_qualified_class_name(),
+                            error_type="SCRAPE_ENTRY_ERROR",
+                            error_message=f"Error scraping entry URL {link.url}: {str(e)}",
                         )
-                        return
-
-                    title = await page.title()
-                    content = await page.content()
-                    urls = urlsplit(current_url)
-                    upath = urls.path
-                    basename = os.path.basename(upath)
-                    _, filetype = os.path.splitext(basename)
-
-                    if not filetype and scraping_request.output_format == ScrapingOutputFormat.TEXT_HTML:
-                        filetype = ".html"
-                    elif scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
-                        filetype = ".md"
-                    elif not filetype:
-                        filetype = ".txt"
-
-                    filename = hashlib.md5(content.encode("utf-8")).hexdigest() + filetype
-
-                    mimetype = mimetypes.guess_type(filename)[0]
-
-                    try:
-                        if scraping_request.output_format == ScrapingOutputFormat.MARKDOWN:
-                            content = md(
-                                content,
-                                **scraping_request.transformer_options,
-                            )
-                        with filesystem.open(f"scraped_data/{filename}", "w") as f:
-                            f.write(content)
-                    except Exception as e:
-                        logging.error(f"Error writing file: {e}")
-                        ctx.send_error(
-                            ErrorMessage(
-                                agent_type=self.get_qualified_class_name(),
-                                error_type="FileWriteError",
-                                error_message=str(e),
-                            )
-                        )
-
-                    meta = link.metadata or {}
-                    metadata = meta | {"scraped_url": current_url, "title": title, "request_id": scraping_request.id}
-
-                    output = MediaLink(
-                        url=f"scraped_data/{filename}",
-                        name=filename,
-                        metadata=metadata,
-                        on_filesystem=True,
-                        mimetype=mimetype,
-                        encoding="utf-8",
                     )
 
-                    scraped_docs.append(output)
-                    self.scraped_urls.add(current_url)
-                    ctx.send(output)
-
-                if link.url not in self.scraped_urls or scraping_request.force:
-                    await scrape_and_store(link.url)
-
-                if scraping_request.depth != 0:
-                    unique_links = await self._extract_links(page, link.url, scraping_request)
-                    for new_url in unique_links[: scraping_request.depth if scraping_request.depth > 0 else None]:
-                        try:
-                            await scrape_and_store(new_url)
-                        except Exception as e:
-                            ctx.send_error(
-                                ErrorMessage(
-                                    agent_type=self.get_qualified_class_name(),
-                                    error_type="SCRAPE_NAV_ERROR",
-                                    error_message=f"Error scraping nav URL {new_url}: {str(e)}",
-                                )
-                            )
-
             await browser.close()
+            await asyncio.sleep(0.1)
 
             unique_scraped_docs = list({doc.name: doc for doc in scraped_docs}.values())
 

--- a/playwright/tests/agent/test_playwright_agent.py
+++ b/playwright/tests/agent/test_playwright_agent.py
@@ -138,19 +138,46 @@ class TestPlaywrightAgent:
         assert result.payload["encoding"] == "utf-8"
         assert result.payload["name"] is not None
 
+        # Give the system a final moment to complete any pending tasks
+        await asyncio.sleep(2)
+
+        # Cancel any remaining tasks explicitly to avoid the warning
+        for task in asyncio.all_tasks():
+            if task is not asyncio.current_task() and not task.done():
+                task.cancel()
+
+    @flaky(max_runs=3, min_passes=1)
+    async def test_recursive_scraping_with_depth(self, generator):
+        filesystem = DependencySpec(
+            class_name="rustic_ai.core.guild.agent_ext.depends.filesystem.FileSystemResolver",
+            properties={
+                "path_base": "/tmp",
+                "protocol": "file",
+                "storage_options": {
+                    "auto_mkdir": True,
+                },
+            },
+        )
+        agent, results = wrap_agent_for_testing(
+            AgentBuilder(PlaywrightScraperAgent)
+            .set_id("002")
+            .set_name("WebScrapperDepth")
+            .set_description("A web scraping agent testing depth")
+            .build(),
+            generator,
+            {"filesystem": filesystem},
+        )
+
+        request_id = shortuuid.uuid()
+
         message = Message(
             id_obj=generator.get_id(Priority.NORMAL),
             topics="default_topic",
             sender=AgentTag(id="testerId", name="tester"),
             payload=WebScrapingRequest(
                 id=request_id,
-                links=[
-                    MediaLink(url="https://webscraper.io/test-sites/e-commerce/static"),
-                ],
-                output_format=ScrapingOutputFormat.MARKDOWN,
-                depth=2,
-                scrape_external_links=False,
-                force=True,
+                links=[MediaLink(url="https://webscraper.io/test-sites/e-commerce/static")],
+                depth=1,
             ).model_dump(),
             format=get_qualified_class_name(WebScrapingRequest),
         )
@@ -161,32 +188,23 @@ class TestPlaywrightAgent:
         tries = 0
 
         while True:
-            await asyncio.sleep(2)
-
+            await asyncio.sleep(3)
             tries += 1
-            if len(results) >= 10 or (results and results[-1].format == wsc) or tries > 10:
+            if results and results[-1].format == wsc:
+                break
+            if tries > 12:
                 break
 
-        latest_results = results[-3:]
-        assert any(
-            result.payload["metadata"]["scraped_url"].startswith("https://webscraper.io")
-            for result in latest_results
-            if isinstance(result.payload, dict)
-        )
-        result = results[-2]
-        assert result.in_response_to == message.id
-        assert result.current_thread_id == message.id
-        assert result.recipient_list == []
+        completed = WebScrapingCompleted.model_validate(results[-1].payload)
 
-        assert result.payload["id"] is not None
-        assert result.payload["mimetype"] == "text/markdown"
-        assert result.payload["encoding"] == "utf-8"
-        assert result.payload["name"] is not None
+        assert completed.id == request_id
+        assert len(completed.links) >= 1
 
-        # Give the system a final moment to complete any pending tasks
-        await asyncio.sleep(2)
+        for result in results[:-1]:
+            assert result.payload["url"].endswith(".html") or result.payload["url"].endswith(".md")
+            fs = filesystem.to_resolver().resolve(agent.guild_id, "GUILD_GLOBAL")
+            assert fs.exists(result.payload["url"])
 
-        # Cancel any remaining tasks explicitly to avoid the warning
         for task in asyncio.all_tasks():
             if task is not asyncio.current_task() and not task.done():
                 task.cancel()

--- a/playwright/tests/agent/test_playwright_agent.py
+++ b/playwright/tests/agent/test_playwright_agent.py
@@ -111,6 +111,7 @@ class TestPlaywrightAgent:
                     MediaLink(url="https://example.com/index.html"),
                 ],
                 output_format=ScrapingOutputFormat.MARKDOWN,
+                force=True,
             ).model_dump(),
             format=get_qualified_class_name(WebScrapingRequest),
         )

--- a/playwright/tests/agent/test_playwright_agent.py
+++ b/playwright/tests/agent/test_playwright_agent.py
@@ -176,7 +176,7 @@ class TestPlaywrightAgent:
             sender=AgentTag(id="testerId", name="tester"),
             payload=WebScrapingRequest(
                 id=request_id,
-                links=[MediaLink(url="https://webscraper.io/test-sites/e-commerce/static")],
+                links=[MediaLink(url="https://gist.github.com/Nihal-Srivastava05/6dfbc56f6aebdf33788eb3d85a67e0f9")],
                 depth=1,
             ).model_dump(),
             format=get_qualified_class_name(WebScrapingRequest),
@@ -201,7 +201,7 @@ class TestPlaywrightAgent:
         assert len(completed.links) >= 1
 
         for result in results[:-1]:
-            assert result.payload["url"].endswith(".html") or result.payload["url"].endswith(".md")
+            assert result.payload["url"].endswith(".html") or result.payload["url"].endswith(".txt")
             fs = filesystem.to_resolver().resolve(agent.guild_id, "GUILD_GLOBAL")
             assert fs.exists(result.payload["url"])
 

--- a/playwright/tests/agent/test_playwright_agent.py
+++ b/playwright/tests/agent/test_playwright_agent.py
@@ -176,7 +176,7 @@ class TestPlaywrightAgent:
             sender=AgentTag(id="testerId", name="tester"),
             payload=WebScrapingRequest(
                 id=request_id,
-                links=[MediaLink(url="https://gist.github.com/Nihal-Srivastava05/6dfbc56f6aebdf33788eb3d85a67e0f9")],
+                links=[MediaLink(url="https://webscraper.io/test-sites/e-commerce/static")],
                 depth=1,
             ).model_dump(),
             format=get_qualified_class_name(WebScrapingRequest),


### PR DESCRIPTION
- Add ability to scrape nav bar links directly with param scrape_nav_links (defaults to 0 which means no nav bar links will be scraped). 
- Also added a set to make sure it doesnt scrape the same link twice, this can be overridden using the force=True which will scrape the link regardless of it was previously scraped 