### PR TITLE
feat: associate guild with organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ uvicorn_output.txt
 api/scripts/zipkin/data-tmp/traces.json
 
 old-docs/
+out/

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -82,8 +82,3 @@ lines_between_sections = 1 # For the newline issue
 known_third_party = ["pydantic"]
 known_first_party = ["rustic_ai.core", "rustic_ai.ray"]
 known_local_folder = ["rustic_ai.testing"]
-
-
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope="function"

--- a/api/src/rustic_ai/api_server/guilds/router.py
+++ b/api/src/rustic_ai/api_server/guilds/router.py
@@ -16,7 +16,7 @@ from starlette import status
 
 from rustic_ai.api_server.api_dependency_manager import ApiDependencyManager
 from rustic_ai.api_server.guilds.comms_manager import GuildCommunicationManager
-from rustic_ai.api_server.guilds.schema import IdInfo
+from rustic_ai.api_server.guilds.schema import IdInfo, LaunchGuildReq
 from rustic_ai.api_server.guilds.service import GuildService
 from rustic_ai.core import Agent
 from rustic_ai.core.agents.commons.media import MediaLink
@@ -32,21 +32,20 @@ guild_service = GuildService()
 
 
 @router.post("/guilds", response_model=IdInfo, status_code=status.HTTP_201_CREATED, operation_id="createGuild")
-def create_guild(guild_spec: GuildSpec):
+def create_guild(launch_req: LaunchGuildReq):
     """
     Creates a new guild and adds it to the database.
 
     Args:
-        guild_spec (GuildSpec): The spec for the new guild
+        launch_req (LaunchGuildReq):  object with spec for the new guild and the org id
 
     Returns:
         IdInfo: The id of the newly created guild
     """
-    if not guild_spec:
+    if not launch_req.spec:
         raise HTTPException(status_code=400, detail="Invalid input")  # pragma: no cover
-
     try:
-        guild_id = guild_service.create_guild(Metastore.get_db_url(), guild_spec)
+        guild_id = guild_service.create_guild(Metastore.get_db_url(), launch_req.spec, launch_req.org_id)
         logging.debug(f"New guild created: {guild_id}")
         return IdInfo(id=guild_id)
     except ValidationError as e:

--- a/api/src/rustic_ai/api_server/guilds/schema.py
+++ b/api/src/rustic_ai/api_server/guilds/schema.py
@@ -1,5 +1,12 @@
 from pydantic import BaseModel
 
+from rustic_ai.core.guild.dsl import GuildSpec
+
 
 class IdInfo(BaseModel):
     id: str
+
+
+class LaunchGuildReq(BaseModel):
+    spec: GuildSpec
+    org_id: str

--- a/api/src/rustic_ai/api_server/guilds/service.py
+++ b/api/src/rustic_ai/api_server/guilds/service.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Sequence
 
 from sqlalchemy import Engine
 
@@ -9,9 +9,17 @@ from rustic_ai.core.guild.metastore import GuildStore
 
 class GuildService:
 
-    def create_guild(self, metastore_url: str, guild_spec: GuildSpec) -> str:
+    def create_guild(self, metastore_url: str, guild_spec: GuildSpec, organization_id: str) -> str:
         """
         Creates a new guild and adds it to the database.
+
+        Args:
+            metastore_url (str): The URL of the metastore database.
+            guild_spec (GuildSpec): The specification of the guild to create.
+            organization_id (str): The ID of the organization that owns this guild.
+
+        Returns:
+            str: The ID of the created guild.
         """
         if guild_spec.get_messaging() is None:
             default_messaging = GuildHelper.get_default_messaging_config()
@@ -22,15 +30,21 @@ class GuildService:
 
         guild_spec.dependency_map = GuildHelper.get_guild_dependency_map(guild_spec)
 
-        guild = GuildBuilder.from_spec(guild_spec).bootstrap(metastore_url)
+        guild = GuildBuilder.from_spec(guild_spec).bootstrap(metastore_url, organization_id)
 
         return guild.id
 
     def get_guild(self, engine: Engine, guild_id: str) -> Optional[GuildSpec]:
         """
         Retrieves a guild and its agents from the database.
-        """
 
+        Args:
+            engine (Engine): The database engine.
+            guild_id (str): The ID of the guild to retrieve.
+
+        Returns:
+            Optional[GuildSpec]: The guild specification if found, None otherwise.
+        """
         guild_store = GuildStore(engine)
         guild_model = guild_store.get_guild(guild_id)
 

--- a/api/tests/catalog/test_blueprint_apis.py
+++ b/api/tests/catalog/test_blueprint_apis.py
@@ -12,6 +12,7 @@ from rustic_ai.api_server.catalog.models import (
     BlueprintReviewCreate,
     CatalogAgentEntry,
 )
+from rustic_ai.api_server.guilds.schema import LaunchGuildReq
 from rustic_ai.core.agents.testutils import EchoAgent
 from rustic_ai.core.guild.dsl import GuildSpec
 from rustic_ai.core.guild.metastore.database import Metastore
@@ -289,15 +290,18 @@ def test_share_blueprint_with_organization(setup_data, catalog_client):
     assert response.status_code == 204
 
 
-def test_blueprint_guild_linking(setup_data, catalog_client):
+def test_blueprint_guild_linking(setup_data, catalog_client, org_id):
     guild_spec = GuildSpec(
         name="MyGuild",
         description="A guild for testing",
         properties={"storage": {"class": "rustic_ai.messaging.storage.InMemoryStorage", "properties": {}}},
         agents=[],
     )
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
     response = catalog_client.post(
-        "/api/guilds", json=guild_spec.model_dump(), headers={"Content-Type": "application/json"}
+        "/api/guilds",
+        json=req.model_dump(),
+        headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 201
     assert "id" in response.json()
@@ -326,15 +330,18 @@ def test_blueprint_guild_linking(setup_data, catalog_client):
     assert response.json()["detail"] == "Blueprint na not found"
 
 
-def test_add_user_to_guild(setup_data, catalog_client):
+def test_add_user_to_guild(setup_data, catalog_client, org_id):
     guild_spec = GuildSpec(
         name="UserGuild ",
         description="A guild for testing",
         properties={"storage": {"class": "rustic_ai.messaging.storage.InMemoryStorage", "properties": {}}},
         agents=[],
     )
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
     response = catalog_client.post(
-        "/api/guilds", json=guild_spec.model_dump(), headers={"Content-Type": "application/json"}
+        "/api/guilds",
+        json=req.model_dump(),
+        headers={"Content-Type": "application/json"},
     )
     guild_id = response.json()["id"]
     # Test when user is not linked to a guild
@@ -356,15 +363,18 @@ def test_add_user_to_guild(setup_data, catalog_client):
     assert delete_response.status_code == 204
 
 
-def test_user_guild_response(setup_data, catalog_client):
+def test_user_guild_response(setup_data, catalog_client, org_id):
     guild_spec = GuildSpec(
         name="UserGuild ",
         description="A guild for testing",
         properties={"storage": {"class": "rustic_ai.messaging.storage.InMemoryStorage", "properties": {}}},
         agents=[],
     )
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
     response = catalog_client.post(
-        "/api/guilds", json=guild_spec.model_dump(), headers={"Content-Type": "application/json"}
+        "/api/guilds",
+        json=req.model_dump(),
+        headers={"Content-Type": "application/json"},
     )
     guild_id = response.json()["id"]
     blueprint_id = setup_data["blueprint"].id
@@ -384,15 +394,18 @@ def test_user_guild_response(setup_data, catalog_client):
     assert guild_res["icon"] == "icon.png"
 
 
-def test_add_org_to_guild(setup_data, catalog_client):
+def test_add_org_to_guild(setup_data, catalog_client, org_id):
     guild_spec = GuildSpec(
         name="OrgGuild ",
         description="A guild for testing",
         properties={"storage": {"class": "rustic_ai.messaging.storage.InMemoryStorage", "properties": {}}},
         agents=[],
     )
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
     response = catalog_client.post(
-        "/api/guilds", json=guild_spec.model_dump(), headers={"Content-Type": "application/json"}
+        "/api/guilds",
+        json=req.model_dump(),
+        headers={"Content-Type": "application/json"},
     )
     guild_id = response.json()["id"]
     # Test when org is not linked to a guild

--- a/api/tests/guilds/test_create_guild.py
+++ b/api/tests/guilds/test_create_guild.py
@@ -1,11 +1,12 @@
 import json
 
+from rustic_ai.api_server.guilds.schema import LaunchGuildReq
 from rustic_ai.core.agents.testutils import EchoAgent
 from rustic_ai.core.guild.builders import AgentBuilder
 from rustic_ai.core.guild.dsl import AgentSpec, GuildSpec
 
 
-def test_create_guild(client):
+def test_create_guild(client, org_id):
     agent1: AgentSpec = AgentBuilder(EchoAgent).set_name("Agent1").set_description("First agent").build_spec()
 
     guild_spec = GuildSpec(
@@ -19,7 +20,8 @@ def test_create_guild(client):
         },
         agents=[agent1],
     )
-    json_data = guild_spec.model_dump_json()
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
+    json_data = req.model_dump_json()
     data = json.loads(json_data)
 
     # Act
@@ -38,7 +40,7 @@ def test_create_guild_invalid_input(client):
     assert response.status_code == 422
 
 
-def test_create_guild_without_agents(client):
+def test_create_guild_without_agents(client, org_id):
     # Arrange
     guild_spec = GuildSpec(
         name="MyGuild",
@@ -51,7 +53,8 @@ def test_create_guild_without_agents(client):
         },
         agents=[],
     )
-    json_data = guild_spec.model_dump_json()
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
+    json_data = req.model_dump_json()
     data = json.loads(json_data)
 
     # Act

--- a/api/tests/guilds/test_get_guild.py
+++ b/api/tests/guilds/test_get_guild.py
@@ -1,11 +1,12 @@
 import json
 
+from rustic_ai.api_server.guilds.schema import LaunchGuildReq
 from rustic_ai.core.agents.testutils import EchoAgent
 from rustic_ai.core.guild.builders import AgentBuilder
 from rustic_ai.core.guild.dsl import AgentSpec, GuildSpec
 
 
-def test_valid_guild_id(client):
+def test_valid_guild_id(client, org_id):
     # Arrange
     agent1: AgentSpec = AgentBuilder(EchoAgent).set_name("Agent1").set_description("First agent").build_spec()
 
@@ -20,7 +21,8 @@ def test_valid_guild_id(client):
         },
         agents=[agent1],
     )
-    json_data = guild_spec.model_dump_json()
+    req = LaunchGuildReq(spec=guild_spec, org_id=org_id)
+    json_data = req.model_dump_json()
     data = json.loads(json_data)
     post_response = client.post("/api/guilds", json=data, headers={"Content-Type": "application/json"})
 

--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,13 @@ from rustic_ai.core.utils.gemstone_id import GemstoneGenerator
 TEST_GUILD_COUNT: int = 0
 
 
+@pytest.fixture(scope="session")
+def org_id():
+    return "acmeorganizationid"
+
+
 @pytest.fixture
-def guild() -> Guild:
+def guild(org_id) -> Guild:
     global TEST_GUILD_COUNT
     TEST_GUILD_COUNT += 1
     guild_id = f"test_guild_{TEST_GUILD_COUNT}"
@@ -29,6 +34,7 @@ def guild() -> Guild:
         description="A test guild",
         execution_engine_clz=SyncExecutionEngine.get_qualified_class_name(),
         messaging_config=messaging_config,
+        organization_id=org_id
     )
 
 

--- a/core/src/rustic_ai/core/agents/system/guild_manager_agent.py
+++ b/core/src/rustic_ai/core/agents/system/guild_manager_agent.py
@@ -58,6 +58,7 @@ class GuildManagerAgent(Agent[GuildManagerAgentProps]):
     ):
         guild_spec = agent_spec.props.guild_spec
         database_url = agent_spec.props.database_url
+        organization_id = agent_spec.properties.organization_id
 
         self.database_url = database_url
         self.engine = Metastore.get_engine(database_url)
@@ -91,13 +92,13 @@ class GuildManagerAgent(Agent[GuildManagerAgentProps]):
             if self.guild_model:
                 logging.info(f"Loading existing guild : [{self.guild_model}]")
                 self.guild_spec = self.guild_model.to_guild_spec()
-                self.guild = GuildBuilder.from_spec(self.guild_spec).load()
+                self.guild = GuildBuilder.from_spec(self.guild_spec).load(self.guild_model.organization_id)
             else:
                 logging.info(f"Creating new guild : [{guild_spec}]")
                 # Create the guild model if it does not exist.
-                self.guild = GuildBuilder.from_spec(guild_spec).launch()
+                self.guild = GuildBuilder.from_spec(guild_spec).launch(organization_id)
                 self.guild_spec = self.guild.to_spec()
-                self.guild_model = GuildModel.from_guild_spec(guild_spec)
+                self.guild_model = GuildModel.from_guild_spec(guild_spec, organization_id)
                 session.add(self.guild_model)
 
                 # Add the agents to the Metastore

--- a/core/src/rustic_ai/core/agents/system/guild_manager_agent_props.py
+++ b/core/src/rustic_ai/core/agents/system/guild_manager_agent_props.py
@@ -8,3 +8,4 @@ class GuildManagerAgentProps(BaseAgentProps):
 
     guild_spec: GuildSpec
     database_url: str
+    organization_id: str

--- a/core/src/rustic_ai/core/guild/execution/execution_engine.py
+++ b/core/src/rustic_ai/core/guild/execution/execution_engine.py
@@ -13,8 +13,9 @@ class ExecutionEngine(ABC):
     with flexible Messaging initialization.
     """
 
-    def __init__(self, guild_id: str) -> None:
+    def __init__(self, guild_id: str, organization_id: str) -> None:
         self.guild_id = guild_id
+        self.organization_id = organization_id
 
     @abstractmethod
     def run_agent(
@@ -31,8 +32,10 @@ class ExecutionEngine(ABC):
         Runs an agent by handling its initialization with the message bus.
 
         Parameters:
-            agent: The agent to run.
-            messaging: Either an instance of MessagingInterface or a configuration to initialize one
+            guild_spec: GuildSpec for which the agent must be run.
+            agent_spec: The agent specification or instance to wrap.
+                NOTE: Providing an Agent is only supported for testing and should not be used in production.
+            messaging_config: MessagingConfig to initialize MessagingInterface for communication between agents.
             machine_id: A unique identifier for the machine generating the ID
             client_type: The type of client to use for the agent.
             client_properties: Properties to initialize the client with.

--- a/core/src/rustic_ai/core/guild/execution/multithreaded/multithreaded_exec_engine.py
+++ b/core/src/rustic_ai/core/guild/execution/multithreaded/multithreaded_exec_engine.py
@@ -14,8 +14,8 @@ from rustic_ai.core.messaging.core import Client, MessagingConfig
 
 
 class MultiThreadedEngine(ExecutionEngine):
-    def __init__(self, guild_id) -> None:
-        super().__init__(guild_id=guild_id)
+    def __init__(self, guild_id, organization_id: str) -> None:
+        super().__init__(guild_id=guild_id, organization_id=organization_id)
         self.agent_wrappers: Dict[str, MultiThreadedAgentWrapper] = {}
 
         # We use the in-memory agent tracker as this is still running in the same process

--- a/core/src/rustic_ai/core/guild/execution/sync/sync_exec_engine.py
+++ b/core/src/rustic_ai/core/guild/execution/sync/sync_exec_engine.py
@@ -9,8 +9,8 @@ from rustic_ai.core.messaging import Client, MessageTrackingClient, MessagingCon
 
 
 class SyncExecutionEngine(ExecutionEngine):
-    def __init__(self, guild_id: str) -> None:
-        super().__init__(guild_id=guild_id)
+    def __init__(self, guild_id: str, organization_id: str) -> None:
+        super().__init__(guild_id=guild_id, organization_id=organization_id)
         self.agent_tracker = InMemorySyncAgentTracker()
         self.owned_agents: List[tuple[str, str]] = []
 
@@ -32,12 +32,14 @@ class SyncExecutionEngine(ExecutionEngine):
         Instantiates a SynchronousAgentWrapper to handle the agent's initialization with the message bus, then runs the agent synchronously.
 
         Parameters:
-            agent: The agent specification or instance to wrap.
+            guild_spec: GuildSpec for which the agent must be run.
+            agent_spec: The agent specification or instance to wrap.
                 NOTE: Providing an Agent is only supported for testing and should not be used in production.
-            messaging_config: Messaging configuration.
-            client_type: The type of client to be used by the agent for communicating with the message bus.
-            client_properties: Additional properties for initializing the client.
-            default_topic: The default topic the agent should subscribe to.
+            messaging_config: MessagingConfig to initialize MessagingInterface for communication between agents.
+            machine_id: A unique identifier for the machine generating the ID
+            client_type: The type of client to use for the agent.
+            client_properties: Properties to initialize the client with.
+            default_topic: The default topic to subscribe to.
         """
         # Instantiate the synchronous agent wrapper with the provided parameters
         guild_id = guild_spec.id

--- a/core/src/rustic_ai/core/guild/guild.py
+++ b/core/src/rustic_ai/core/guild/guild.py
@@ -12,15 +12,12 @@ from rustic_ai.core.utils.class_utils import create_execution_engine
 
 
 class Guild:
-    """
-    A class representing a guild of agents, updated to use a pluggable ExecutionEngine.
-    """
-
     def __init__(
         self,
         id: str,
         name: str,
         description: str,
+        organization_id: str,
         execution_engine_clz: str,
         messaging_config: MessagingConfig,
         client_type: Type[Client] = MessageTrackingClient,
@@ -35,16 +32,18 @@ class Guild:
             id: The ID of the guild.
             name: The name of the guild.
             description: A description of the guild.
-            execution_engine: The execution engine to run agents within the guild.
-            messaging: Either an instance of MessagingInterface or a configuration
-                to initialize one to use for communication between agents.
+            execution_engine_clz: The execution engine class to run agents within the guild.
+            messaging_config: MessagingConfig to initialize MessagingInterface for communication between agents.
             client_type: The default client type for agents within the guild.
             client_properties: Default properties for initializing clients for the agents.
         """
         self.id = id
         self.name = name
         self.description = description
-        self.execution_engine = create_execution_engine(execution_engine_clz, guild_id=id)
+        self.organization_id = organization_id
+        self.execution_engine = create_execution_engine(
+            execution_engine_clz, guild_id=id, organization_id=organization_id
+        )
         self.messaging = messaging_config
         self.client_type = client_type
         self.client_properties = client_properties
@@ -72,7 +71,7 @@ class Guild:
         Adds an agent to the guild and uses the execution engine to run it.
 
         Parameters:
-            agent: The agent to add and run.
+            agent_spec: The agent to add and run.
         """
         assert isinstance(agent_spec, AgentSpec), "agent_spec must be an instance of AgentSpec"
         self._internal_add_agent(agent_spec, execution_engine)

--- a/core/src/rustic_ai/core/guild/metastore/guild_store.py
+++ b/core/src/rustic_ai/core/guild/metastore/guild_store.py
@@ -26,12 +26,19 @@ class GuildStore:
             session.close()
         return guild_model
 
-    def add_guild(self, guild_spec: GuildSpec) -> GuildModel:
+    def add_guild(self, guild_spec: GuildSpec, organization_id: str) -> GuildModel:
         """
         Add a guild to the metastore.
+
+        Args:
+            guild_spec (GuildSpec): The guild specification to add.
+            organization_id (str): The ID of the organization that owns this guild.
+
+        Returns:
+            GuildModel: The added guild model.
         """
         with Session(self.engine) as session:
-            guild_model = GuildModel.from_guild_spec(guild_spec)
+            guild_model = GuildModel.from_guild_spec(guild_spec, organization_id)
             session.add(guild_model)
             session.commit()
             session.refresh(guild_model)
@@ -39,10 +46,29 @@ class GuildStore:
 
     def list_guilds(self) -> Sequence[GuildModel]:
         """
-        List the guilds in the metastore.
+        List all guilds in the metastore.
+
+        Returns:
+            Sequence[GuildModel]: A list of all guild models.
         """
         with Session(self.engine) as session:
             get_guilds_stmt = select(GuildModel)
+            guilds = session.exec(get_guilds_stmt).unique().all()
+            session.close()
+        return guilds
+
+    def list_guilds_by_organization(self, organization_id: str) -> Sequence[GuildModel]:
+        """
+        List guilds belonging to a specific organization.
+
+        Args:
+            organization_id (str): The ID of the organization to filter by.
+
+        Returns:
+            Sequence[GuildModel]: A list of guild models belonging to the specified organization.
+        """
+        with Session(self.engine) as session:
+            get_guilds_stmt = select(GuildModel).where(GuildModel.organization_id == organization_id)
             guilds = session.exec(get_guilds_stmt).unique().all()
             session.close()
         return guilds

--- a/core/src/rustic_ai/core/guild/metastore/models.py
+++ b/core/src/rustic_ai/core/guild/metastore/models.py
@@ -174,6 +174,8 @@ class GuildModel(SQLModel, table=True):
     backend_class: str = Field(default="InMemoryMessagingBackend")
     backend_config: dict = Field(sa_column=Column(MutableDict.as_mutable(JSON(none_as_null=True)), default={}))
 
+    organization_id: str = Field(index=True, nullable=False)
+
     dependency_map: dict = Field(sa_column=Column(MutableDict.as_mutable(JSON(none_as_null=True)), default={}))
 
     routes: list[GuildRoutes] = Relationship(
@@ -191,12 +193,13 @@ class GuildModel(SQLModel, table=True):
         return session.get(cls, guild_id)
 
     @classmethod
-    def from_guild_spec(cls, guild_spec: GuildSpec) -> "GuildModel":
+    def from_guild_spec(cls, guild_spec: GuildSpec, organization_id: str) -> "GuildModel":
         """
         Create a GuildModel instance from a GuildSpec instance.
 
         Args:
             guild_spec (GuildSpec): The GuildSpec instance.
+            organization_id (str, optional): The ID of the organization that owns this guild.
 
         Returns:
             GuildModel: The GuildModel instance. This instance DOES NOT have the agents populated.
@@ -222,6 +225,7 @@ class GuildModel(SQLModel, table=True):
             backend_module=backend.backend_module,
             backend_class=backend.backend_class,
             backend_config=backend.backend_config,
+            organization_id=organization_id,
             dependency_map=deps_map,
             routes=routes,
         )

--- a/core/src/rustic_ai/core/utils/class_utils.py
+++ b/core/src/rustic_ai/core/utils/class_utils.py
@@ -35,9 +35,9 @@ def get_execution_class(full_class_name: str) -> Type[ExecutionEngine]:
     return execution_class
 
 
-def create_execution_engine(full_class_name: str, guild_id: str) -> ExecutionEngine:
+def create_execution_engine(full_class_name: str, guild_id: str, organization_id: str) -> ExecutionEngine:
     execution_class = get_execution_class(full_class_name)
-    return execution_class(guild_id=guild_id)
+    return execution_class(guild_id=guild_id, organization_id=organization_id)
 
 
 def get_client_class(full_class_name: str) -> Type[Client]:

--- a/core/tests/guild/agent_ext/depends/test_agent_di.py
+++ b/core/tests/guild/agent_ext/depends/test_agent_di.py
@@ -42,7 +42,7 @@ class SearchIndexDependencyResolver(DependencyResolver):
 
 class TestAgentDependencyInjection:
 
-    def test_agent_di(self, probe_agent: ProbeAgent):
+    def test_agent_di(self, probe_agent: ProbeAgent, org_id):
         agent_spec: AgentSpec = (
             AgentBuilder(DemoAgent1).set_description("Demo agent with dependencies").set_name("DemoAgent1").build_spec()
         )
@@ -77,7 +77,7 @@ class TestAgentDependencyInjection:
         assert gspec.dependency_map["filepath"].class_name == FilepathDependencyResolver.get_qualified_class_name()
         assert gspec.dependency_map["filepath"].properties["prefix"] == "rustic-files"
 
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
 
         guild._add_local_agent(probe_agent)
 

--- a/core/tests/guild/agent_ext/depends/test_di_filesystem.py
+++ b/core/tests/guild/agent_ext/depends/test_di_filesystem.py
@@ -148,7 +148,7 @@ class TestFileSystem:
             ),
         ],
     )
-    def test_filesystem(self, probe_agent: ProbeAgent, dep_map: Dict[str, DependencySpec]):
+    def test_filesystem(self, probe_agent: ProbeAgent, dep_map: Dict[str, DependencySpec], org_id):
         agent_spec: AgentSpec = (
             AgentBuilder(FileManagerAgent)
             .set_id("file_manager")
@@ -169,7 +169,7 @@ class TestFileSystem:
         fs = filesystem(protocol, **protocol_props)
 
         dfs = FileSystem(path="/tmp/test_guild/file_manager", fs=fs)
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
 
         guild._add_local_agent(probe_agent)
 

--- a/core/tests/guild/agent_ext/depends/test_di_kvstore.py
+++ b/core/tests/guild/agent_ext/depends/test_di_kvstore.py
@@ -181,7 +181,7 @@ class BaseTestKVStore(ABC):
         """
         raise NotImplementedError("This fixture should be overridden in subclasses.")
 
-    def test_kvstore(self, probe_agent: ProbeAgent, dep_map: dict):
+    def test_kvstore(self, probe_agent: ProbeAgent, dep_map: dict, org_id):
         agent_spec: AgentSpec = (
             AgentBuilder(KVStoreAgent).set_description("KV Store Agent").set_name("KVStoreAgent").build_spec()
         )
@@ -191,7 +191,7 @@ class BaseTestKVStore(ABC):
             .add_agent_spec(agent_spec)
             .set_dependency_map(dep_map)
         )
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
 
         if "kvstore" in dep_map:
             guild.dependency_map["kvstore"].class_name = dep_map["kvstore"].class_name

--- a/core/tests/guild/agent_ext/mixins/test_health_mixin.py
+++ b/core/tests/guild/agent_ext/mixins/test_health_mixin.py
@@ -54,10 +54,10 @@ class TestHealthMixin:
         yield db
         Metastore.drop_db()
 
-    def test_health_mixin(self, guild_id, guild_name, guild_description, echo_agent, database):
+    def test_health_mixin(self, guild_id, guild_name, guild_description, echo_agent, database, org_id):
         builder = GuildBuilder(guild_id, guild_name, guild_description).add_agent_spec(echo_agent)
 
-        guild = builder.bootstrap(database)
+        guild = builder.bootstrap(database, org_id)
 
         probe_agent = (
             AgentBuilder(EssentialProbeAgent)

--- a/core/tests/guild/metastore/test_guild_store.py
+++ b/core/tests/guild/metastore/test_guild_store.py
@@ -39,33 +39,33 @@ class TestGuildStore:
     def _get_guild(self, name):
         return GuildBuilder(name).set_name(name).set_description(name).build_spec()
 
-    def test_add_guild(self, engine, guild):
+    def test_add_guild(self, engine, guild, org_id):
         store = GuildStore(engine)
-        gm1 = store.add_guild(guild)
+        gm1 = store.add_guild(guild, org_id)
         assert gm1.id == "guild1"
         guild = store.get_guild(gm1.id)
         assert guild.id == "guild1"
 
-    def test_list_guilds(self, engine, guild):
+    def test_list_guilds(self, engine, guild, org_id):
         store = GuildStore(engine)
-        store.add_guild(guild)
-        store.add_guild(self._get_guild("guild2"))
+        store.add_guild(guild, org_id)
+        store.add_guild(self._get_guild("guild2"), org_id)
         guilds = store.list_guilds()
         assert len(guilds) == 2
 
         assert guilds[0].id == "guild1"
         assert guilds[1].id == "guild2"
 
-    def test_remove_guild(self, engine, guild):
+    def test_remove_guild(self, engine, guild, org_id):
         store = GuildStore(engine)
-        store.add_guild(guild)
+        store.add_guild(guild, org_id)
         store.remove_guild(guild.id)
         guild = store.get_guild(guild.id)
         assert guild is None
 
-    def test_add_agent(self, engine, guild, agent):
+    def test_add_agent(self, engine, guild, agent, org_id):
         store = GuildStore(engine)
-        store.add_guild(guild)
+        store.add_guild(guild, org_id)
         store.add_agent(guild.id, agent)
 
         agent2 = self._get_agent("agent2")
@@ -92,9 +92,9 @@ class TestGuildStore:
         guilds = store.list_guilds()
         assert guilds == []
 
-    def test_remove_guild_none(self, engine, guild):
+    def test_remove_guild_none(self, engine, guild, org_id):
         store = GuildStore(engine)
-        store.add_guild(guild)
+        store.add_guild(guild, org_id)
         gm = store.get_guild(guild.id)
 
         assert gm is not None
@@ -106,10 +106,10 @@ class TestGuildStore:
 
         assert guild is None
 
-    def test_remove_agent(self, engine, guild, agent):
+    def test_remove_agent(self, engine, guild, agent, org_id):
         store = GuildStore(engine)
 
-        store.add_guild(guild)
+        store.add_guild(guild, org_id)
         store.add_agent(guild.id, agent)
 
         gm = store.get_guild(guild.id)
@@ -132,17 +132,17 @@ class TestGuildStore:
         with pytest.raises(ValueError):
             store.remove_agent("test_guild", "test_agent")
 
-    def test_remove_agent_guild_none(self, engine, guild):
+    def test_remove_agent_guild_none(self, engine, guild, org_id):
 
         store = GuildStore(engine)
-        store.add_guild(guild)
+        store.add_guild(guild, org_id)
 
         with pytest.raises(ValueError):
             store.remove_agent(guild.id, "test_agent")
 
-    def test_list_agents(self, engine, guild, agent):
+    def test_list_agents(self, engine, guild, agent, org_id):
         store = GuildStore(engine)
-        store.add_guild(guild)
+        store.add_guild(guild, org_id)
 
         agent2 = self._get_agent("agent2")
         store.add_agent(guild.id, agent)
@@ -155,9 +155,9 @@ class TestGuildStore:
 
         assert agents[1].name == "agent2"
 
-    def test_model_from_spec(self):
+    def test_model_from_spec(self, org_id):
         spec = GuildBuilder("guild1").set_name("guild1").set_description("guild1").build_spec()
-        gm = GuildModel.from_guild_spec(spec)
+        gm = GuildModel.from_guild_spec(spec, org_id)
 
         assert gm.id == "guild1"
         assert gm.name == "guild1"
@@ -168,7 +168,7 @@ class TestGuildStore:
         assert gm.backend_class == "InMemoryMessagingBackend"
         assert gm.backend_config == {}
 
-    def test_model_with_routing_rules(self, engine):
+    def test_model_with_routing_rules(self, engine, org_id):
         guild_id = "guild_with_routing"
 
         spec = (
@@ -219,7 +219,7 @@ class TestGuildStore:
         )
 
         store = GuildStore(engine)
-        store.add_guild(spec)
+        store.add_guild(spec, org_id)
 
         guild_model = store.get_guild(guild_id)
 
@@ -277,7 +277,7 @@ class TestGuildStore:
         assert isinstance(rule04.transformer, FunctionalTransformer)
         assert rule04.transformer.handler == "{'payload': {'new_key': payload.key, 'origin_id': $.origin.id}}"
 
-    def test_model_with_dependencies(self, engine):
+    def test_model_with_dependencies(self, engine, org_id):
         guild_id = "guild_with_deps"
 
         builder = (
@@ -320,7 +320,7 @@ class TestGuildStore:
         spec = builder.build_spec()
 
         store = GuildStore(engine)
-        store.add_guild(spec)
+        store.add_guild(spec, org_id)
         store.add_agent(guild_id, agent)
 
         guild_model = store.get_guild(guild_id)

--- a/core/tests/guild/test_agent_tagging.py
+++ b/core/tests/guild/test_agent_tagging.py
@@ -7,7 +7,7 @@ from rustic_ai.core.messaging.core.message import AgentTag
 
 class TestAgentTagging:
 
-    def test_only_when_tagged(self):
+    def test_only_when_tagged(self, org_id):
 
         # 2 Agents that only act when tagged
         echo1: AgentSpec = (
@@ -44,7 +44,7 @@ class TestAgentTagging:
             .add_agent_spec(echo1)
             .add_agent_spec(echo2)
             .add_agent_spec(echo3)
-            .launch()
+            .launch(organization_id=org_id)
         )
 
         probe_agent = AgentBuilder(ProbeAgent).set_name("probe").set_description("Probe agent").build()

--- a/core/tests/guild/test_guild.py
+++ b/core/tests/guild/test_guild.py
@@ -30,7 +30,7 @@ class TestGuild:
         return AgentBuilder(SimpleAgent).set_id(agent_id).set_name(name).set_description(description).build_spec()
 
     @pytest.fixture
-    def guild(self, messaging):
+    def guild(self, messaging, org_id):
         guild_id = "e1"
         name = "Guild1"
         description = "Test Guild"
@@ -41,11 +41,12 @@ class TestGuild:
             description=description,
             execution_engine_clz=execution_engine,
             messaging_config=messaging,
+            organization_id=org_id,
         )
         yield guild
         guild.shutdown()
 
-    def test_guild_initialization(self, messaging):
+    def test_guild_initialization(self, messaging, org_id):
         guild_id = "e1"
         name = "Guild1"
         description = "Test Guild"
@@ -58,6 +59,7 @@ class TestGuild:
             description=description,
             execution_engine_clz=execution_engine,
             messaging_config=messaging,
+            organization_id=org_id,
         )
 
         assert guild.id == guild_id
@@ -65,7 +67,7 @@ class TestGuild:
         assert guild.description == description
         assert guild.messaging == messaging
 
-    def test_guild_initialization_with_messaging_config(self):
+    def test_guild_initialization_with_messaging_config(self, org_id):
         messaging_config = MessagingConfig(
             backend_module="rustic_ai.core.messaging.backend",
             backend_class="InMemoryMessagingBackend",
@@ -84,6 +86,7 @@ class TestGuild:
             description=description,
             execution_engine_clz=execution_engine,
             messaging_config=messaging_config,
+            organization_id=org_id,
         )
 
         assert guild.id == guild_id

--- a/core/tests/guild/test_guild_builder.py
+++ b/core/tests/guild/test_guild_builder.py
@@ -198,16 +198,16 @@ class TestGuildBuilder:
         assert spec.properties[GSKC.MESSAGING][GSKC.BACKEND_CLASS] == backend_class
         assert spec.properties[GSKC.MESSAGING][GSKC.BACKEND_CONFIG] == backend_config
 
-    def test_guild_launch(self, agent_spec, guild_id, guild_name, guild_description):
+    def test_guild_launch(self, agent_spec, guild_id, guild_name, guild_description, org_id):
         builder = GuildBuilder(guild_id, guild_name, guild_description).add_agent_spec(agent_spec)
-        guild = builder.launch()
+        guild = builder.launch(organization_id=org_id)
         assert guild.id == guild_id
         assert guild.name == guild_name
         assert guild.get_agent(agent_spec.id) == agent_spec
 
-    def test_guild_load(self, agent_spec, guild_id, guild_name, guild_description):
+    def test_guild_load(self, agent_spec, guild_id, guild_name, guild_description, org_id):
         builder = GuildBuilder(guild_id, guild_name, guild_description).add_agent_spec(agent_spec)
-        guild = builder.load()
+        guild = builder.load(organization_id=org_id)
         assert guild.id == guild_id
         assert guild.name == guild_name
         assert guild.get_agent(agent_spec.id) == agent_spec
@@ -282,7 +282,7 @@ class TestGuildBuilder:
 
         msgconf = GuildHelper.get_messaging_config(new_spec)
 
-        # This is not paramterized as we are testing initialization from a YAML file
+        # This is not parameterized as we are testing initialization from a YAML file
         assert msgconf.backend_module == "rustic_ai.core.messaging.backend"
         assert msgconf.backend_class == "InMemoryMessagingBackend"
         assert msgconf.backend_config == {}
@@ -296,6 +296,7 @@ class TestGuildBuilder:
         guild_description,
         messaging: MessagingConfig,
         database,
+        org_id,
     ):
 
         routing_slip = RoutingSlip(
@@ -323,7 +324,7 @@ class TestGuildBuilder:
 
         engine = Metastore.get_engine(database)
 
-        guild = builder.bootstrap(database)
+        guild = builder.bootstrap(database, org_id)
         assert guild.id == guild_id
         assert guild.name == guild_name
 
@@ -498,6 +499,7 @@ class TestGuildBuilder:
         guild_description,
         messaging: MessagingConfig,
         database,
+        org_id,
     ):
         builder = (
             GuildBuilder(guild_id, guild_name, guild_description)
@@ -519,7 +521,7 @@ class TestGuildBuilder:
 
         engine = Metastore.get_engine(database)
 
-        guild = builder.bootstrap(database)
+        guild = builder.bootstrap(database, org_id)
 
         time.sleep(0.5)
 
@@ -757,12 +759,7 @@ class TestGuildBuilder:
         probe_agent.clear_messages()
 
     def test_message_broadcast(
-        self,
-        guild_id,
-        guild_name,
-        guild_description,
-        messaging: MessagingConfig,
-        database,
+        self, guild_id, guild_name, guild_description, messaging: MessagingConfig, database, org_id
     ):
         builder = GuildBuilder(guild_id, guild_name, guild_description).set_messaging(
             messaging.backend_module,
@@ -770,7 +767,7 @@ class TestGuildBuilder:
             messaging.backend_config,
         )
 
-        guild = builder.bootstrap(database)
+        guild = builder.bootstrap(database, org_id)
 
         time.sleep(0.5)
 

--- a/core/tests/guild/test_guild_stop.py
+++ b/core/tests/guild/test_guild_stop.py
@@ -40,12 +40,7 @@ class TestGuildStop:
         yield db
         Metastore.drop_db()
 
-    def test_guild_bootstrap(
-        self,
-        messaging: MessagingConfig,
-        probe_agent: ProbeAgent,
-        database,
-    ):
+    def test_guild_bootstrap(self, messaging: MessagingConfig, probe_agent: ProbeAgent, database, org_id):
 
         guild_id = "guild_stop_test"
         guild_name = "Guild1"
@@ -83,7 +78,7 @@ class TestGuildStop:
             )
         )
 
-        guild = builder.bootstrap(database)
+        guild = builder.bootstrap(database, org_id)
 
         time.sleep(2)
         running_agents = guild.execution_engine.get_agents_in_guild(guild_id)

--- a/core/tests/guild/test_spec_build.py
+++ b/core/tests/guild/test_spec_build.py
@@ -19,7 +19,7 @@ class TestBuildFromSpec:
     exec_engine_clz: str = "rustic_ai.core.guild.execution.sync.sync_exec_engine.SyncExecutionEngine"
 
     #  Builds a Guild instance from a valid GuildSpec.
-    def test_build_from_valid_guild_spec(self, client_properties):
+    def test_build_from_valid_guild_spec(self, client_properties, org_id):
         guild_spec = GuildSpec(
             name="MyGuild",
             description="A guild for testing",
@@ -48,7 +48,7 @@ class TestBuildFromSpec:
             ],
         )
 
-        guild = GuildBuilder.from_spec(guild_spec).launch()
+        guild = GuildBuilder.from_spec(guild_spec).launch(organization_id=org_id)
 
         assert isinstance(guild, Guild)
         assert guild.name == "MyGuild"
@@ -71,7 +71,7 @@ class TestBuildFromSpec:
         assert isinstance(guild.messaging, MessagingConfig)
 
     #  Builds a Guild instance with multiple agents.
-    def test_build_with_multiple_agents(self, client_properties):
+    def test_build_with_multiple_agents(self, client_properties, org_id):
         guild_spec = GuildSpec(
             name="MyGuild",
             description="A guild for testing",
@@ -99,7 +99,7 @@ class TestBuildFromSpec:
             ],
         )
 
-        guild = GuildBuilder.from_spec(guild_spec).launch()
+        guild = GuildBuilder.from_spec(guild_spec).launch(organization_id=org_id)
 
         assert guild.get_agent_count() == 2
 
@@ -121,7 +121,7 @@ class TestBuildFromSpec:
         assert agent2.props.prop2 == 1
 
     #  Builds a Guild instance with a storage backend specified in the GuildSpec.
-    def test_build_with_storage_backend(self, client_properties):
+    def test_build_with_storage_backend(self, client_properties, org_id):
         guild_spec = GuildSpec(
             name="MyGuild",
             description="A guild for testing",
@@ -141,12 +141,12 @@ class TestBuildFromSpec:
             ],
         )
 
-        guild = GuildBuilder.from_spec(guild_spec).launch()
+        guild = GuildBuilder.from_spec(guild_spec).launch(organization_id=org_id)
 
         assert isinstance(guild.messaging, MessagingConfig)
 
     #  Builds a Guild instance with an empty agents dictionary.
-    def test_build_with_empty_agents(self, client_properties):
+    def test_build_with_empty_agents(self, client_properties, org_id):
         guild_spec = GuildSpec(
             name="MyGuild",
             description="A guild for testing",
@@ -160,12 +160,12 @@ class TestBuildFromSpec:
             agents=[],
         )
 
-        guild = GuildBuilder.from_spec(guild_spec).launch()
+        guild = GuildBuilder.from_spec(guild_spec).launch(organization_id=org_id)
 
         assert guild.get_agent_count() == 0
 
     #  Builds a Guild instance with an empty properties dictionary.
-    def test_build_with_empty_properties(self, client_properties):
+    def test_build_with_empty_properties(self, client_properties, org_id):
         guild_spec = GuildSpec(
             name="MyGuild",
             description="A guild for testing",
@@ -182,7 +182,7 @@ class TestBuildFromSpec:
             ],
         )
 
-        guild = GuildBuilder.from_spec(guild_spec).launch()
+        guild = GuildBuilder.from_spec(guild_spec).launch(organization_id=org_id)
 
         assert isinstance(guild, Guild)
         assert guild.name == "MyGuild"
@@ -195,11 +195,11 @@ class TestBuildFromSpec:
         assert agent1.description == "First agent"
         assert agent1.class_name == get_qualified_class_name(SimpleAgent)
 
-    def test_null_case(self):
+    def test_null_case(self, org_id):
         guild_spec: GuildSpec = None  # type: ignore
 
         with pytest.raises(ValueError):
-            GuildBuilder.from_spec(guild_spec).launch()
+            GuildBuilder.from_spec(guild_spec).launch(organization_id=org_id)
 
     #  Builds a Guild instance from a valid GuildSpec.
     def test_build_with_invalid_agent_class_name(self, client_properties):

--- a/core/tests/integration/execution/base_test_integration.py
+++ b/core/tests/integration/execution/base_test_integration.py
@@ -27,17 +27,22 @@ class IntegrationTestABC(ABC):
         return "test_guild_id"
 
     @pytest.fixture
+    def org_id(self) -> str:
+        return "test_org_id"
+
+    @pytest.fixture
     def wait_time(self) -> float:
         return 0.01
 
     @pytest.fixture
-    def guild(self, wait_time, messaging, execution_engine, guild_id):
+    def guild(self, wait_time, messaging, execution_engine, guild_id, org_id):
         guild = Guild(
             id=guild_id,
             name="Test Guild",
             description="A guild for integration testing",
             messaging_config=messaging,
             execution_engine_clz=execution_engine,
+            organization_id=org_id,
         )
         yield guild
         time.sleep(wait_time * 5)  # Allow some time for cleanup
@@ -103,7 +108,7 @@ class IntegrationTestABC(ABC):
         rair = execution_engine.is_agent_running(guild.id, ra[0].id)
         assert rair is True
 
-        local_exec_engine = SyncExecutionEngine(guild_id=guild.id)
+        local_exec_engine = SyncExecutionEngine(guild_id=guild.id, organization_id=guild.organization_id)
         guild._add_local_agent(local_test_agent, local_exec_engine)
 
         time.sleep(wait_time)

--- a/huggingface/tests/agents/diffusion/test_pix2pix.py
+++ b/huggingface/tests/agents/diffusion/test_pix2pix.py
@@ -19,7 +19,7 @@ from rustic_ai.huggingface.agents.diffusion.pix2pix import Image2ImageAgent, Ima
 
 class TestPix2PixAgent:
     @pytest.mark.skipif(os.getenv("SKIP_EXPENSIVE_TESTS") == "true", reason="Skipping expensive tests")
-    def test_response_is_generated(self, probe_agent: ProbeAgent):
+    def test_response_is_generated(self, probe_agent: ProbeAgent, org_id):
         """
         Test that the agent responds to a message with a message containing the filepath of the generated image.
         """
@@ -65,7 +65,7 @@ class TestPix2PixAgent:
         fs.copy(data_file_path, data_file_in_fs_path)
         assert fs.exists(data_file_in_fs_path)
 
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
         guild._add_local_agent(probe_agent)
 
         probe_agent.publish_dict(

--- a/huggingface/tests/agents/diffusion/test_stable_diffusion_agent.py
+++ b/huggingface/tests/agents/diffusion/test_stable_diffusion_agent.py
@@ -21,7 +21,7 @@ from rustic_ai.huggingface.agents.models import ImageGenerationRequest
 
 class TestRunwaymlStableDiffusionAgent:
     @pytest.mark.skipif(os.getenv("SKIP_EXPENSIVE_TESTS") == "true", reason="Skipping expensive tests")
-    def test_response_is_generated(self, probe_agent: ProbeAgent):
+    def test_response_is_generated(self, probe_agent: ProbeAgent, org_id):
         """
         Test that the agent responds to a message with a message.
         """
@@ -60,7 +60,7 @@ class TestRunwaymlStableDiffusionAgent:
 
         dfs = FileSystem(path="/tmp/stable_diff_guild/GUILD_GLOBAL", fs=fs)
 
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
         guild._add_local_agent(probe_agent)
 
         generation_prompt = "Canopy of trees"

--- a/huggingface/tests/agents/text_to_speech/test_speecht5_tts_agent.py
+++ b/huggingface/tests/agents/text_to_speech/test_speecht5_tts_agent.py
@@ -19,7 +19,7 @@ from rustic_ai.huggingface.agents.text_to_speech.speecht5_tts_agent import (
 
 class TestSpeechT5TtsAgent:
 
-    def test_response_is_generated(self, probe_agent: ProbeAgent):
+    def test_response_is_generated(self, probe_agent: ProbeAgent, org_id):
         """
         Test that the agent responds to a message with a message containing the filepath of the generated audio.
         """
@@ -58,7 +58,7 @@ class TestSpeechT5TtsAgent:
 
         dfs = FileSystem(path="/tmp/speecht5_tts_guild/GUILD_GLOBAL", fs=fs)
 
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
         guild._add_local_agent(probe_agent)
 
         probe_agent.publish_dict(

--- a/it/agents/indexing/test_vector_agent.py
+++ b/it/agents/indexing/test_vector_agent.py
@@ -26,7 +26,7 @@ from rustic_ai.langchain.agent_ext.text_splitter.character_splitter import (
 
 @pytest.mark.skipif(os.getenv("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY environment variable not set")
 class TestVectorAgent:
-    def test_vector_agent(self, probe_agent: ProbeAgent):
+    def test_vector_agent(self, probe_agent: ProbeAgent, org_id):
         guild_id = "test_vector_guild"
         dep_map = {
             "vectorstore": DependencySpec(
@@ -66,7 +66,7 @@ class TestVectorAgent:
         fs = filesystem(protocol, **protocol_props)
         dfs = FileSystem(path=f"/tmp/{guild_id}/GUILD_GLOBAL", fs=fs)
 
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(org_id)
         guild._add_local_agent(probe_agent)
 
         # Upsert documents

--- a/it/dependency/test_filesystem_api.py
+++ b/it/dependency/test_filesystem_api.py
@@ -57,11 +57,12 @@ class TestFilesystemAPI:
         return GemstoneGenerator(1)
 
     @pytest.mark.asyncio
-    async def test_upload_file(self, guild: GuildSpec):
+    async def test_upload_file(self, guild: GuildSpec, org_id):
         server = "127.0.0.1:8880"
 
         async with httpx.AsyncClient(base_url=f"http://{server}") as ac:
-            new_guild_resp = await ac.post("/api/guilds", json=guild.model_dump())
+            guild_data = {**guild.model_dump(), "organization_id": org_id}
+            new_guild_resp = await ac.post("/api/guilds", json=guild_data)
 
             assert new_guild_resp.status_code == 201
             guild_id = new_guild_resp.json()["id"]

--- a/it/state/test_state_mgmt.py
+++ b/it/state/test_state_mgmt.py
@@ -102,7 +102,7 @@ class TestStateMgmt:
         yield db
         Metastore.drop_db()
 
-    def test_state_mgmt(self, state_aware_agent: AgentSpec, state_free_agent: AgentSpec, database):
+    def test_state_mgmt(self, state_aware_agent: AgentSpec, state_free_agent: AgentSpec, database, org_id):
         builder = (
             GuildBuilder("state_guild", "State Guild", "Guild to test state management")
             .add_agent_spec(state_aware_agent)
@@ -115,7 +115,7 @@ class TestStateMgmt:
         )
 
         engine = Metastore.get_engine(database)  # noqa: F841
-        guild = builder.bootstrap(database)
+        guild = builder.bootstrap(database, org_id)
 
         probe_agent: ProbeAgent = (
             AgentBuilder(ProbeAgent)

--- a/it/websocket/test_socket.py
+++ b/it/websocket/test_socket.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 import websockets
 
+from rustic_ai.api_server.guilds.schema import LaunchGuildReq
 from rustic_ai.core.agents.testutils.echo_agent import EchoAgent
 from rustic_ai.core.agents.utils.user_proxy_agent import UserProxyAgent
 from rustic_ai.core.guild.builders import AgentBuilder, GuildBuilder
@@ -83,7 +84,7 @@ class TestServer:
         return GemstoneGenerator(1)
 
     @pytest.mark.asyncio
-    async def test_websocket_interaction(self, guild: GuildSpec, generator: GemstoneGenerator):
+    async def test_websocket_interaction(self, guild: GuildSpec, generator: GemstoneGenerator, org_id):
         server = "127.0.0.1:8880"
         wait_time = 0.5
 
@@ -108,7 +109,9 @@ class TestServer:
         guild.routes = routing_slip
 
         async with httpx.AsyncClient(base_url=f"http://{server}") as client:
-            new_guild_resp = await asyncio.wait_for(client.post("/api/guilds", json=guild.model_dump()), wait_time)
+            req = LaunchGuildReq(spec=guild, org_id=org_id)
+            req_data = json.loads(req.model_dump_json())
+            new_guild_resp = await asyncio.wait_for(client.post("/api/guilds", json=req_data), wait_time)
 
             assert new_guild_resp.status_code == 201
             time.sleep(wait_time)

--- a/marvin/pyproject.toml
+++ b/marvin/pyproject.toml
@@ -74,7 +74,3 @@ known_first_party = ["rustic_ai.core", "rustic_ai.marvin"]
 known_local_folder = ["rustic_ai.testing"]
 
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope="function"
-

--- a/playwright/pyproject.toml
+++ b/playwright/pyproject.toml
@@ -76,6 +76,3 @@ known_third_party = ["pydantic"]
 known_first_party = ["rustic_ai.core","rustic_ai.playwright"]
 known_local_folder = ["rustic_ai.testing"]
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope="function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ exclude = [
     "^\\.tox/",
     "^cache/",
     "cookiecutter-rustic/",
+    "out/"
 ]
 
 

--- a/redis/pyproject.toml
+++ b/redis/pyproject.toml
@@ -71,9 +71,3 @@ lines_between_sections = 1 # For the newline issue
 known_third_party = ["pydantic"]
 known_first_party = ["rustic_ai.core", "rustic_ai.redis"]
 known_local_folder = ["rustic_ai.testing"]
-
-
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope="function"
-norecursedirs = ["cookiecutter-rustic"]

--- a/showcase/tests/laira/test_research_guild.py
+++ b/showcase/tests/laira/test_research_guild.py
@@ -104,7 +104,7 @@ class TestResearchGuild:
         return deps_yaml_path
 
     @pytest.fixture
-    def research_guild(self, routing_slip, rgdatabase, dep_map_config):
+    def research_guild(self, routing_slip, rgdatabase, dep_map_config, org_id):
         research_guild_builder = GuildBuilder(
             guild_id=f"research_guild_{shortuuid.uuid()}",
             guild_name="Research Guild",
@@ -149,7 +149,7 @@ class TestResearchGuild:
         research_guild_builder.add_agent_spec(serp_agent)
         research_guild_builder.add_agent_spec(playwright_agent)
 
-        research_guild = research_guild_builder.set_routes(routing_slip).bootstrap(rgdatabase)
+        research_guild = research_guild_builder.set_routes(routing_slip).bootstrap(rgdatabase, org_id)
 
         yield research_guild
         research_guild.shutdown()
@@ -225,7 +225,7 @@ class TestResearchGuild:
 
         final_response = messages[-1]
 
-        assert len(messages) > 20
+        assert len(messages) >= 20
 
         assert final_response.format == tf
 

--- a/testing/src/rustic_ai/testing/agent_ext/base_test_kvstore.py
+++ b/testing/src/rustic_ai/testing/agent_ext/base_test_kvstore.py
@@ -181,7 +181,7 @@ class BaseTestKVStore(ABC):
         """
         raise NotImplementedError("This fixture should be overridden in subclasses.")
 
-    def test_kvstore(self, probe_agent: ProbeAgent, dep_map: dict):
+    def test_kvstore(self, probe_agent: ProbeAgent, dep_map: dict, org_id):
         agent_spec: AgentSpec = (
             AgentBuilder(KVStoreAgent).set_description("KV Store Agent").set_name("KVStoreAgent").build_spec()
         )
@@ -191,7 +191,7 @@ class BaseTestKVStore(ABC):
             .add_agent_spec(agent_spec)
             .set_dependency_map(dep_map)
         )
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
 
         if "kvstore" in dep_map:
             guild.dependency_map["kvstore"].class_name = dep_map["kvstore"].class_name

--- a/testing/src/rustic_ai/testing/execution/base_test_integration.py
+++ b/testing/src/rustic_ai/testing/execution/base_test_integration.py
@@ -31,13 +31,14 @@ class IntegrationTestABC(ABC):
         return 0.01
 
     @pytest.fixture
-    def guild(self, wait_time, messaging, execution_engine, guild_id):
+    def guild(self, wait_time, messaging, execution_engine, guild_id, org_id):
         guild = Guild(
             id=guild_id,
             name="Test Guild",
             description="A guild for integration testing",
             messaging_config=messaging,
             execution_engine_clz=execution_engine,
+            organization_id=org_id,
         )
         yield guild
         time.sleep(wait_time * 5)  # Allow some time for cleanup
@@ -103,7 +104,7 @@ class IntegrationTestABC(ABC):
         rair = execution_engine.is_agent_running(guild.id, ra[0].id)
         assert rair is True
 
-        local_exec_engine = SyncExecutionEngine(guild_id=guild.id)
+        local_exec_engine = SyncExecutionEngine(guild_id=guild.id, organization_id=guild.organization_id)
         guild._add_local_agent(local_test_agent, local_exec_engine)
 
         time.sleep(wait_time)

--- a/vertexai/tests/agents/test_imagen_agent.py
+++ b/vertexai/tests/agents/test_imagen_agent.py
@@ -21,7 +21,7 @@ from rustic_ai.vertexai.agents.image_generation import (
 
 class TestImagenAgent:
     @pytest.mark.skipif(os.getenv("SKIP_EXPENSIVE_TESTS") == "true", reason="Skipping expensive tests")
-    def test_response_is_generated(self, probe_agent: ProbeAgent):
+    def test_response_is_generated(self, probe_agent: ProbeAgent, org_id):
         """
         Test that the agent responds to a message with a message.
         """
@@ -60,7 +60,7 @@ class TestImagenAgent:
 
         dfs = FileSystem(path="/tmp/imagen_guild/GUILD_GLOBAL", fs=fs)
 
-        guild = guild_builder.launch()
+        guild = guild_builder.launch(organization_id=org_id)
         guild._add_local_agent(probe_agent)
 
         probe_agent.publish_dict(


### PR DESCRIPTION
This introduces a breaking change - launching a guild now requires a organization_id

TODOs
- [ ] add API to list guilds by organization
- [ ] check and update docs 