### PR TITLE
fix: add agent_state and guild_state to payload transform

### DIFF
--- a/core/src/rustic_ai/core/messaging/core/message.py
+++ b/core/src/rustic_ai/core/messaging/core/message.py
@@ -136,7 +136,7 @@ class PayloadTransformer(Transformer):
         A simple transformer that applies a JSONata expression to the message payload.
         This transformer is basic and acts only on the payload.
         """
-        data = routable.payload
+        data = dict(routable.payload, agent_state=agent_state, guild_state=guild_state)
 
         try:
             if self.expression:

--- a/core/tests/guild/test_guild_stop.py
+++ b/core/tests/guild/test_guild_stop.py
@@ -83,7 +83,7 @@ class TestGuildStop:
         time.sleep(2)
         running_agents = guild.execution_engine.get_agents_in_guild(guild_id)
         assert len(running_agents) == 2
-         
+
         guild._add_local_agent(probe_agent)
 
         probe_agent.publish_dict(

--- a/core/tests/messaging/core/test_message.py
+++ b/core/tests/messaging/core/test_message.py
@@ -383,7 +383,7 @@ class TestMessage:
         transformed = transformer.transform(origin=origin, agent_state={}, guild_state={}, routable=routable)
 
         assert transformed is not None
-        assert transformed.payload == {"key": "value"}
+        assert transformed.payload == {"key": "value", "agent_state": {}, "guild_state": {}}
 
     def test_simple_transformer_with_expression(self, generator):
         transformer = PayloadTransformer(expression="{'new_key': $.key}")


### PR DESCRIPTION
- `agent_state` and `guild_state` were missing in the data param of the payload transform which lead to those not being accessible and returned as empty when using in PayloadTranform expressions. 
- Fixed the test for test_message.py as well.