### PR TITLE
fix(core): stop guild 

### DIFF
--- a/api/src/rustic_ai/api_server/catalog/catalog_store.py
+++ b/api/src/rustic_ai/api_server/catalog/catalog_store.py
@@ -372,6 +372,7 @@ class CatalogStore:
                     GuildModel.name,
                     Blueprint.id.label("blueprint_id"),  # type:ignore
                     Blueprint.icon,
+                    GuildModel.status
                 )
                 .select_from(GuildModel)
                 .outerjoin(BlueprintGuild, GuildModel.id == BlueprintGuild.guild_id)  # type:ignore
@@ -413,6 +414,7 @@ class CatalogStore:
                     GuildModel.name,
                     Blueprint.id.label("blueprint_id"),  # type:ignore
                     Blueprint.icon,
+                    GuildModel.status
                 )
                 .select_from(
                     join(GuildModel, UserGuild, GuildModel.id == UserGuild.guild_id)  # type:ignore

--- a/api/src/rustic_ai/api_server/catalog/models.py
+++ b/api/src/rustic_ai/api_server/catalog/models.py
@@ -283,6 +283,7 @@ class BasicGuildInfo(SQLModel):
     name: str
     blueprint_id: Optional[str] = Field(default=None)
     icon: Optional[str] = Field(default=None)
+    status: str
 
 
 class AgentIcon(SQLModel, table=True):

--- a/core/src/rustic_ai/core/guild/agent_ext/depends/llm/tools_manager.py
+++ b/core/src/rustic_ai/core/guild/agent_ext/depends/llm/tools_manager.py
@@ -4,6 +4,7 @@ import json
 from typing import List, Optional
 
 from pydantic import BaseModel
+
 from rustic_ai.core.utils.basic_class_utils import get_qualified_class_name
 
 from .....utils import ModelClass

--- a/core/src/rustic_ai/core/guild/metastore/models.py
+++ b/core/src/rustic_ai/core/guild/metastore/models.py
@@ -20,6 +20,7 @@ class GuildStatus(str, Enum):
     STARTING = "starting"
     RUNNING = "running"
     STOPPED = "stopped"
+    STOPPING = "stopping"
 
 
 class GuildRoutes(SQLModel, table=True):


### PR DESCRIPTION
### Issue
When user sends the stop guild message, it takes a while for all the agents to be stopped. If user accidentally tries to reconnect to the guild during this time through a reload, it results in inconsistent system behaviour on async execution engines like RayExecutionEngine. 

### Changes
* Stop GuildManagerAgent after updating status.
* Set guild status to stopping immediately after receiving the stop request and then update it to stopped after all the other agents have been terminated. This provides better clarity into the status.
* Include guild status in the responses for list guilds APIs. This can be leveraged by UIs display/hide stopped guilds as desired.