### PR TITLE
feat: additional fields in ui dataFormat to handle updates

### DIFF
--- a/core/src/rustic_ai/core/agents/testutils/ui_component_agent.py
+++ b/core/src/rustic_ai/core/agents/testutils/ui_component_agent.py
@@ -22,6 +22,7 @@ from rustic_ai.core.ui_protocol.types import (
     TableFormat,
     TableHeader,
     TextFormat,
+    UpdateType,
     VegaLiteFormat,
     VideoFormat,
     Weather,
@@ -395,3 +396,18 @@ class UiComponentAgent(Agent):
             ],
         )
         ctx.send(payload=chat_response)
+
+        # Update messages
+        text_msg_1 = TextFormat(
+            updateId="test_update_text", text="This is a text message example", title="update text format example"
+        )
+        ctx.send_dict(payload=text_msg_1.model_dump(), format="updateTextFormat")
+
+        text_msg_2 = TextFormat(
+            updateId="test_update_text",
+            text="This text should be appended to previous text in UI",
+            title="update text format example",
+            updateType=UpdateType.APPEND,
+        )
+
+        ctx.send_dict(payload=text_msg_2.model_dump(), format="updateTextFormat")

--- a/core/src/rustic_ai/core/ui_protocol/types.py
+++ b/core/src/rustic_ai/core/ui_protocol/types.py
@@ -11,13 +11,12 @@ from typing import Dict, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 
-from rustic_ai.core import AgentTag
 from rustic_ai.core.agents.commons.media import MediaLink
 
 
 class UpdateType(str, Enum):
-    append = "append"
-    replace = "replace"
+    APPEND = "append"
+    REPLACE = "replace"
 
 
 class DataFormat(BaseModel):
@@ -25,9 +24,8 @@ class DataFormat(BaseModel):
 
     title: Optional[str] = None
     description: Optional[str] = None
-    tagged_users: list[AgentTag] = []
-    update_id: Optional[str] = None
-    update_type: Optional[UpdateType] = None
+    update_id: Optional[str] = Field(default=None, alias="updateId")
+    update_type: Optional[UpdateType] = Field(None, alias="updateType")
 
 
 class VisualizationFormat(DataFormat):

--- a/core/src/rustic_ai/core/ui_protocol/types.py
+++ b/core/src/rustic_ai/core/ui_protocol/types.py
@@ -15,12 +15,19 @@ from rustic_ai.core import AgentTag
 from rustic_ai.core.agents.commons.media import MediaLink
 
 
+class UpdateType(str, Enum):
+    append = "append"
+    replace = "replace"
+
+
 class DataFormat(BaseModel):
     """Base class for all message data formats."""
 
     title: Optional[str] = None
     description: Optional[str] = None
     tagged_users: list[AgentTag] = []
+    update_id: Optional[str] = None
+    update_type: Optional[UpdateType] = None
 
 
 class VisualizationFormat(DataFormat):

--- a/showcase/tests/ui_components/test_ui_component_blueprint.py
+++ b/showcase/tests/ui_components/test_ui_component_blueprint.py
@@ -18,6 +18,7 @@ from rustic_ai.core.ui_protocol.types import (
     QuestionFormat,
     TableFormat,
     TextFormat,
+    UpdateType,
     VegaLiteFormat,
     VideoFormat,
     WeatherFormat,
@@ -75,7 +76,8 @@ class TestUiComponentBlueprint:
         # QuestionFormat, FormFormat, CodeFormat, CalendarFormat, WeatherFormat,
         # LocationFormat, ImageFormat, MermaidFormat, PlotlyGraphFormat,
         # VegaLiteFormat, TableFormat, PerspectiveFormat, AudioFormat, VideoFormat, ChatCompletionResponse
-        assert len(messages) == 20, f"Expected 20 messages, got {len(messages)}"
+        # updateTextFormat(2)
+        assert len(messages) == 22, f"Expected 22 messages, got {len(messages)}"
 
         # Helper function to get messages by format
         def get_messages_by_format(format_class):
@@ -221,5 +223,14 @@ class TestUiComponentBlueprint:
         video_payload = video_messages[0].payload
         assert "rustic-ai.github.io" in video_payload["src"]
         assert video_payload["title"] == "Training Video"
+
+        # Verify Update message
+        update_messages = get_messages_by_format_name("updateTextFormat")
+        assert len(update_messages) == 2
+        update_msg_payload_1 = update_messages[0].payload
+        update_msg_payload_2 = update_messages[1].payload
+        assert update_msg_payload_1["update_id"] == update_msg_payload_2["update_id"]
+        assert update_msg_payload_1["update_type"] is None
+        assert update_msg_payload_2["update_type"] == UpdateType.APPEND
 
         guild.shutdown()


### PR DESCRIPTION
I've removed tagged_users from `DataFormat` as it is part of the `Message` itself - `recepientList` 